### PR TITLE
Erc 721 precompile part 1

### DIFF
--- a/docs/spec/04-asset-lifecycle.md
+++ b/docs/spec/04-asset-lifecycle.md
@@ -58,6 +58,9 @@ used by compliance/statistics/checkpoints.
 | `NumberOfNFTs` / `NFTsInCollection` | per-DID count / total supply | :93/:127 |
 | `NFTHolder` / `Owner` | account-key-held NFTs (`NFTOwnerStatus`: Owner/OwnerLocked) / reverse owner lookup | :141/:154 |
 | `CurrentNFTId` / `CurrentCollectionId` | id sequences (start at 1) | :132/:137 |
+| `NFTAccountCount` | per-account-key count; portfolio counterpart is `pallet_portfolio::PortfolioNFTCount`. Zero is never stored. Backs the ERC-721 `balanceOf` | nft:167 |
+| `TokenApproval` | (asset, NFTId) → approved account. ERC-721 per-token approval; cleared on every transfer | nft:186 |
+| `OperatorApproval` | (owner, operator, asset) → bool. ERC-721 `setApprovalForAll`, scoped to one collection. `false` is never stored | nft:200 |
 
 ## 2. Ticker system
 
@@ -161,6 +164,20 @@ guards (:513-518). Holder placement: portfolio (via portfolio pallet) or account
 Caller: agent + holding perms **with custody** (:556). NFT must be held and not locked
 (:560-567). Metadata drained (:581); account-key strong ref removed when holdings empty
 (:1026-1030).
+
+### Approvals (`approve`, call_index 5; `set_approval_for_all`, call_index 6)
+
+Two independent mechanisms, both account-key scoped (portfolio-held NFTs cannot be approved):
+
+- **Per-token** (`TokenApproval`): set by the current account holder or by an approved operator
+  (`NFTApprovalNotAuthorized` otherwise). Passing `spender = None` revokes. Consumed on use and
+  cleared inside `remove_nft_from_asset_holder`, so it never survives a transfer.
+- **Operator** (`OperatorApproval`): collection-wide, not consumed on use, not cleared on
+  transfer. Scoped to a single collection — approving an operator on one collection grants
+  nothing on any other.
+
+Consumption happens in settlement's `ensure_transfer_source_authorized` via
+`Nft::spend_nft_approval`; see doc 09 §4.
 
 ### NFT transfers — see doc 09 §6 (validation `validate_nft_transfer` :631; **no statistics for
 NFTs**, compliance checked :688; per-leg cap `MaxNumberOfNFTsCount` = 10).

--- a/docs/spec/09-asset-transfers.md
+++ b/docs/spec/09-asset-transfers.md
@@ -69,9 +69,12 @@ these wrappers never touch portfolios.
 
 **Sender authorization** (`ensure_transfer_source_authorized`, settlement:1660-1695):
 - Account source, caller == owner: implicit.
-- Account source, caller ≠ owner: **spender mode** — `Asset::spend_allowance(owner, caller,
-  asset, amount)` (settlement:1673, asset:2782). NFTs not supported
-  (`AllowancesNotSupportedForNFTs`).
+- Account source, caller ≠ owner: **spender mode**. Fungible funds consume the allowance via
+  `Asset::spend_allowance(owner, caller, asset, amount)` (settlement:1673, asset:2782). NFT funds
+  consume an approval via `Nft::spend_nft_approval(owner, caller, nfts)` — a collection-wide
+  operator approval (`OperatorApproval`) authorizes every NFT and is not consumed, otherwise each
+  NFT needs a per-token approval (`TokenApproval`) naming the caller, which is consumed on use
+  (`InsufficientNFTApproval` otherwise).
 - Portfolio source: custody + portfolio permission (:1686-1692) — works cross-DID for custodians.
 
 **Same-DID branch** (settlement:1596-1638): amount > 0, asset not frozen, holder not frozen,

--- a/pallets/nft/src/benchmarking.rs
+++ b/pallets/nft/src/benchmarking.rs
@@ -263,4 +263,53 @@ benchmarks! {
         assert_eq!(NFTsInCollection::<T>::get(nfts.asset_id()), n as u64);
     }
 
+    approve {
+        let alice = UserBuilder::<T>::default().generate_did().build("Alice");
+        let bob = UserBuilder::<T>::default().generate_did().build("Bob");
+        let alice_holdings = AssetHolder::try_from(alice.account().encode()).unwrap();
+        let asset_id = create_collection_issue_nfts::<T>(&alice, 0, 1, alice_holdings.into());
+        let spender = Pallet::<T>::to_account_id32(&bob.account()).unwrap();
+        // Worst case: overwrite an existing approval.
+        TokenApproval::<T>::insert(asset_id, NFTId(1), &spender);
+    }: _(alice.origin.clone(), asset_id, NFTId(1), Some(bob.account()))
+    verify {
+        assert_eq!(TokenApproval::<T>::get(asset_id, NFTId(1)), Some(spender));
+    }
+
+    set_approval_for_all {
+        let alice = UserBuilder::<T>::default().generate_did().build("Alice");
+        let bob = UserBuilder::<T>::default().generate_did().build("Bob");
+        let alice_holdings = AssetHolder::try_from(alice.account().encode()).unwrap();
+        let asset_id = create_collection_issue_nfts::<T>(&alice, 0, 1, alice_holdings.into());
+        let owner = Pallet::<T>::to_account_id32(&alice.account()).unwrap();
+        let operator = Pallet::<T>::to_account_id32(&bob.account()).unwrap();
+    }: _(alice.origin.clone(), asset_id, bob.account(), true)
+    verify {
+        assert!(OperatorApproval::<T>::get((&owner, &operator, &asset_id)));
+    }
+
+    spend_nft_approval {
+        let n in 1..T::MaxNumberOfNFTsCount::get();
+
+        let alice = UserBuilder::<T>::default().generate_did().build("Alice");
+        let bob = UserBuilder::<T>::default().generate_did().build("Bob");
+        let alice_holdings = AssetHolder::try_from(alice.account().encode()).unwrap();
+        let asset_id = create_collection_issue_nfts::<T>(&alice, 0, n, alice_holdings.into());
+
+        let owner = Pallet::<T>::to_account_id32(&alice.account()).unwrap();
+        let spender = Pallet::<T>::to_account_id32(&bob.account()).unwrap();
+        // Worst case: no operator approval, so every per-token approval is read and consumed.
+        for i in 1..n + 1 {
+            TokenApproval::<T>::insert(asset_id, NFTId(i.into()), &spender);
+        }
+        let nfts = NFTs::new_unverified(asset_id, (1..n + 1).map(|i| NFTId(i.into())).collect());
+    }: {
+        Pallet::<T>::spend_nft_approval(&owner, &bob.account(), &nfts).unwrap();
+    }
+    verify {
+        for i in 1..n + 1 {
+            assert!(TokenApproval::<T>::get(asset_id, NFTId(i.into())).is_none());
+        }
+    }
+
 }

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -35,6 +35,8 @@ type PortfolioPallet<T> = pallet_portfolio::Pallet<T>;
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 
+pub mod migrations;
+
 pub trait WeightInfo {
     fn create_nft_collection(n: u32) -> Weight;
     fn issue_nft(n: u32) -> Weight;
@@ -67,7 +69,7 @@ pub mod pallet {
         type MaxNumberOfNFTsCount: Get<u32>;
     }
 
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(7);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(8);
 
     #[pallet::pallet]
     #[pallet::storage_version(STORAGE_VERSION)]
@@ -161,6 +163,25 @@ pub mod pallet {
         NFTId,
         AssetHolder,
         OptionQuery,
+    >;
+
+    /// The number of NFTs of a given collection held by an account key.
+    ///
+    /// This is the account-level counterpart of `pallet_portfolio::PortfolioNFTCount`, mirroring
+    /// the split used by `pallet_asset::FrozenBalance` / `PortfolioFrozenAssets`. A zero count is
+    /// never stored; the entry is removed instead.
+    ///
+    /// Unlike [`NumberOfNFTs`], which aggregates over a whole identity, this is scoped to a
+    /// single account key and is what the ERC-721 precompile reports as `balanceOf`.
+    #[pallet::storage]
+    pub type NFTAccountCount<T: Config> = StorageDoubleMap<
+        _,
+        Twox64Concat,
+        AccountId32,
+        Blake2_128Concat,
+        AssetId,
+        NFTCount,
+        ValueQuery,
     >;
 
     #[pallet::genesis_config]
@@ -1002,6 +1023,10 @@ impl<T: Config> Pallet<T> {
         match asset_owner {
             AssetHolder::Account(ref acc_id) => {
                 if !NFTHolder::<T>::contains_key((acc_id, &asset_id, &nft_id)) {
+                    Self::mutate_account_nft_count(acc_id, &asset_id, |count| {
+                        count.saturating_add(1)
+                    });
+
                     let acc_id = pallet_base::pallet_account_id::<T>(acc_id)?;
                     IdentityPallet::<T>::add_account_key_ref_count(&acc_id);
                 }
@@ -1024,6 +1049,10 @@ impl<T: Config> Pallet<T> {
         match asset_holder {
             AssetHolder::Account(acc_id) => {
                 if NFTHolder::<T>::contains_key((acc_id, asset_id, nft_id)) {
+                    Self::mutate_account_nft_count(acc_id, asset_id, |count| {
+                        count.saturating_sub(1)
+                    });
+
                     let acc_id = pallet_base::pallet_account_id::<T>(&acc_id)?;
                     IdentityPallet::<T>::remove_account_key_ref_count(&acc_id);
                 }
@@ -1035,6 +1064,41 @@ impl<T: Config> Pallet<T> {
         }
         Owner::<T>::remove(asset_id, nft_id);
         Ok(())
+    }
+
+    /// Returns the number of NFTs of `asset_id` held by `asset_holder`.
+    ///
+    /// Unlike [`NumberOfNFTs`], which aggregates over a whole identity, this is scoped to a
+    /// single account key or portfolio.
+    pub fn get_holders_nft_count(asset_holder: &AssetHolder, asset_id: &AssetId) -> NFTCount {
+        match asset_holder {
+            AssetHolder::Account(acc_id) => Self::get_account_nft_count(acc_id, asset_id),
+            AssetHolder::Portfolio(portfolio_id) => {
+                PortfolioPallet::<T>::get_portfolio_nft_count(portfolio_id, asset_id)
+            }
+        }
+    }
+
+    /// Returns the number of NFTs of `asset_id` held by the `acc_id` account key.
+    pub fn get_account_nft_count(acc_id: &AccountId32, asset_id: &AssetId) -> NFTCount {
+        NFTAccountCount::<T>::get(acc_id, asset_id)
+    }
+
+    /// Mutates the number of NFTs of `asset_id` held by the `acc_id` account key.
+    ///
+    /// `f` receives the current count and returns the new one. A resulting count of zero removes
+    /// the entry rather than storing the default.
+    fn mutate_account_nft_count(
+        acc_id: &AccountId32,
+        asset_id: &AssetId,
+        f: impl FnOnce(NFTCount) -> NFTCount,
+    ) {
+        let count = f(NFTAccountCount::<T>::get(acc_id, asset_id));
+        if count == 0 {
+            NFTAccountCount::<T>::remove(acc_id, asset_id);
+        } else {
+            NFTAccountCount::<T>::insert(acc_id, asset_id, count);
+        }
     }
 
     /// Returns `true` if the `asset_holder` holds the given `nft_id` of the `asset_id`

--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::Encode;
+use codec::{Decode, Encode};
 use frame_support::dispatch::{DispatchResult, DispatchResultWithPostInfo, PostDispatchInfo};
 use frame_support::pallet_prelude::DispatchError;
 use frame_support::traits::Get;
@@ -43,6 +43,9 @@ pub trait WeightInfo {
     fn redeem_nft(n: u32) -> Weight;
     fn base_nft_transfer(n: u32) -> Weight;
     fn controller_transfer(n: u32) -> Weight;
+    fn approve() -> Weight;
+    fn set_approval_for_all() -> Weight;
+    fn spend_nft_approval(n: u32) -> Weight;
 }
 
 pub use pallet::*;
@@ -90,6 +93,29 @@ pub mod pallet {
             Option<AssetHolder>,
             HoldingsUpdateReason,
         ),
+        /// A per-token approval was set or revoked.
+        ///
+        /// `spender` is `None` when the approval was revoked.
+        NFTApproval {
+            owner: AccountId32,
+            spender: Option<AccountId32>,
+            asset_id: AssetId,
+            nft_id: NFTId,
+        },
+        /// A collection-wide operator approval was granted or revoked.
+        NFTApprovalForAll {
+            owner: AccountId32,
+            operator: AccountId32,
+            asset_id: AssetId,
+            approved: bool,
+        },
+        /// A spender consumed a per-token approval to transfer an NFT.
+        NFTApprovalSpent {
+            owner: AccountId32,
+            spender: AccountId32,
+            asset_id: AssetId,
+            nft_id: NFTId,
+        },
     }
 
     /// The total number of NFTs per identity.
@@ -181,6 +207,42 @@ pub mod pallet {
         Blake2_128Concat,
         AssetId,
         NFTCount,
+        ValueQuery,
+    >;
+
+    /// The account approved to transfer a specific NFT, if any.
+    ///
+    /// Mirrors the ERC-721 per-token approval. The entry is cleared whenever the NFT changes
+    /// hands, so an approval never survives a transfer.
+    #[pallet::storage]
+    pub type TokenApproval<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        AssetId,
+        Blake2_128Concat,
+        NFTId,
+        AccountId32,
+        OptionQuery,
+    >;
+
+    /// Collection-wide operator approvals, keyed by `(owner, operator, asset_id)`.
+    ///
+    /// Mirrors the ERC-721 `setApprovalForAll`, but scoped to a single collection rather than to
+    /// every collection the owner holds: each ERC-721 precompile address is one collection, and
+    /// this matches `pallet_asset::Allowances` being per-`AssetId`. `false` is never stored; the
+    /// entry is removed instead.
+    ///
+    /// Uses `StorageNMap` so that all operator approvals of a given owner can be iterated by
+    /// prefix.
+    #[pallet::storage]
+    pub type OperatorApproval<T: Config> = StorageNMap<
+        _,
+        (
+            NMapKey<Blake2_128Concat, AccountId32>,
+            NMapKey<Blake2_128Concat, AccountId32>,
+            NMapKey<Blake2_128Concat, AssetId>,
+        ),
+        bool,
         ValueQuery,
     >;
 
@@ -335,6 +397,66 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             Self::base_transfer_nft(origin, nfts, to, memo)
         }
+
+        /// Approves `spender` to transfer the `nft_id` NFT of the `asset_id` collection on the
+        /// caller's behalf.
+        ///
+        /// This is the ERC-721 per-token approval. The approval is consumed when used and is
+        /// cleared whenever the NFT changes hands, so it never survives a transfer.
+        ///
+        /// Passing `None` for `spender` revokes any existing approval.
+        ///
+        /// # Arguments
+        /// * `origin` - Signed origin. Must hold the NFT in its account key, or be an approved
+        ///   operator for the collection.
+        /// * `asset_id` - the [`AssetId`] of the NFT collection.
+        /// * `nft_id` - the [`NFTId`] of the NFT being approved.
+        /// * `spender` - the account authorized to transfer the NFT, or `None` to revoke.
+        ///
+        /// # Errors
+        /// * `NFTApprovalNotAuthorized` - the caller neither holds the NFT nor is an approved
+        ///   operator for the collection.
+        ///
+        /// # Permissions
+        /// * Asset
+        #[pallet::call_index(5)]
+        #[pallet::weight(<T as Config>::WeightInfo::approve())]
+        pub fn approve(
+            origin: OriginFor<T>,
+            asset_id: AssetId,
+            nft_id: NFTId,
+            spender: Option<T::AccountId>,
+        ) -> DispatchResult {
+            Self::base_approve(origin, asset_id, nft_id, spender)
+        }
+
+        /// Grants or revokes `operator` the right to transfer any NFT of the `asset_id`
+        /// collection held by the caller's account key.
+        ///
+        /// This is the ERC-721 `setApprovalForAll`, scoped to a single collection rather than to
+        /// every collection the caller holds.
+        ///
+        /// Unlike a per-token approval, an operator approval is not consumed on use and is not
+        /// cleared when an NFT is transferred.
+        ///
+        /// # Arguments
+        /// * `origin` - Signed origin.
+        /// * `asset_id` - the [`AssetId`] of the NFT collection.
+        /// * `operator` - the account being granted or revoked.
+        /// * `approved` - `true` to grant, `false` to revoke.
+        ///
+        /// # Permissions
+        /// * Asset
+        #[pallet::call_index(6)]
+        #[pallet::weight(<T as Config>::WeightInfo::set_approval_for_all())]
+        pub fn set_approval_for_all(
+            origin: OriginFor<T>,
+            asset_id: AssetId,
+            operator: T::AccountId,
+            approved: bool,
+        ) -> DispatchResult {
+            Self::base_set_approval_for_all(origin, asset_id, operator, approved)
+        }
     }
 
     #[pallet::error]
@@ -397,6 +519,13 @@ pub mod pallet {
         NumberOfKeysIsLessThanExpected,
         /// The NFT is not locked.
         NFTIsNotLocked,
+        /// The caller is not allowed to approve a spender for this NFT.
+        ///
+        /// Only the account key that currently holds the NFT, or an approved operator for the
+        /// collection, may set a per-token approval.
+        NFTApprovalNotAuthorized,
+        /// The spender has no approval to transfer this NFT.
+        InsufficientNFTApproval,
     }
 }
 
@@ -817,6 +946,128 @@ impl<T: Config> Pallet<T> {
         Ok(PostDispatchInfo::from(Some(weight_meter.consumed())))
     }
 
+    /// Sets or revokes the per-token approval for `nft_id`.
+    fn base_approve(
+        origin: T::RuntimeOrigin,
+        asset_id: AssetId,
+        nft_id: NFTId,
+        spender: Option<T::AccountId>,
+    ) -> DispatchResult {
+        let caller_data = IdentityPallet::<T>::ensure_origin_call_permissions(origin)?;
+        let owner = Self::to_account_id32(&caller_data.sender)?;
+
+        // Only the account key currently holding the NFT, or an approved operator for the
+        // collection, may set a per-token approval.
+        let holder = AssetHolder::Account(owner.clone());
+        ensure!(
+            Self::is_holder_of_nft(&asset_id, &nft_id, &holder)
+                || Self::is_approved_operator_of_nft(&asset_id, &nft_id, &owner),
+            Error::<T>::NFTApprovalNotAuthorized
+        );
+
+        let spender = spender.map(|s| Self::to_account_id32(&s)).transpose()?;
+        match &spender {
+            Some(spender) => TokenApproval::<T>::insert(asset_id, nft_id, spender),
+            None => TokenApproval::<T>::remove(asset_id, nft_id),
+        }
+
+        Self::deposit_event(Event::NFTApproval {
+            owner,
+            spender,
+            asset_id,
+            nft_id,
+        });
+        Ok(())
+    }
+
+    /// Grants or revokes a collection-wide operator approval.
+    fn base_set_approval_for_all(
+        origin: T::RuntimeOrigin,
+        asset_id: AssetId,
+        operator: T::AccountId,
+        approved: bool,
+    ) -> DispatchResult {
+        let caller_data = IdentityPallet::<T>::ensure_origin_call_permissions(origin)?;
+        let owner = Self::to_account_id32(&caller_data.sender)?;
+        let operator = Self::to_account_id32(&operator)?;
+
+        // `false` is never stored; the entry is removed instead.
+        if approved {
+            OperatorApproval::<T>::insert((&owner, &operator, &asset_id), true);
+        } else {
+            OperatorApproval::<T>::remove((&owner, &operator, &asset_id));
+        }
+
+        Self::deposit_event(Event::NFTApprovalForAll {
+            owner,
+            operator,
+            asset_id,
+            approved,
+        });
+        Ok(())
+    }
+
+    /// Checks and consumes `spender`'s approval to transfer `nfts` on `owner`'s behalf.
+    ///
+    /// An operator approval for the collection authorizes every NFT in `nfts` and is not
+    /// consumed. Otherwise each NFT must carry a per-token approval naming `spender`, which is
+    /// consumed on use.
+    ///
+    /// # Errors
+    /// * `InsufficientNFTApproval` - the spender is not approved for one of the NFTs.
+    pub fn spend_nft_approval(
+        owner: &AccountId32,
+        spender: &T::AccountId,
+        nfts: &NFTs,
+    ) -> DispatchResult {
+        let spender = Self::to_account_id32(spender)?;
+        let asset_id = *nfts.asset_id();
+
+        // A collection-wide operator approval covers every NFT and is never consumed.
+        if OperatorApproval::<T>::get((owner, &spender, &asset_id)) {
+            return Ok(());
+        }
+
+        for nft_id in nfts.ids() {
+            ensure!(
+                TokenApproval::<T>::get(&asset_id, nft_id).as_ref() == Some(&spender),
+                Error::<T>::InsufficientNFTApproval
+            );
+            // Consume the approval. It would be cleared by the transfer anyway, but doing it here
+            // keeps `spend_nft_approval` correct on its own.
+            TokenApproval::<T>::remove(&asset_id, nft_id);
+
+            Self::deposit_event(Event::NFTApprovalSpent {
+                owner: owner.clone(),
+                spender: spender.clone(),
+                asset_id,
+                nft_id: *nft_id,
+            });
+        }
+        Ok(())
+    }
+
+    /// Returns `true` if `account` is an approved operator for the holder of `nft_id`.
+    fn is_approved_operator_of_nft(
+        asset_id: &AssetId,
+        nft_id: &NFTId,
+        account: &AccountId32,
+    ) -> bool {
+        match Owner::<T>::get(asset_id, nft_id) {
+            Some(AssetHolder::Account(owner)) => {
+                OperatorApproval::<T>::get((&owner, account, asset_id))
+            }
+            // Portfolio-held NFTs cannot have approvals: `approve` requires an account holder.
+            _ => false,
+        }
+    }
+
+    /// Converts a `T::AccountId` into the `AccountId32` used by the NFT storage maps.
+    fn to_account_id32(acc_id: &T::AccountId) -> Result<AccountId32, DispatchError> {
+        AccountId32::decode(&mut &acc_id.encode()[..])
+            .map_err(|_| pallet_base::Error::<T>::InvalidAccountId.into())
+    }
+
     pub fn base_controller_transfer(
         origin: T::RuntimeOrigin,
         nfts: NFTs,
@@ -1057,6 +1308,9 @@ impl<T: Config> Pallet<T> {
                     IdentityPallet::<T>::remove_account_key_ref_count(&acc_id);
                 }
                 NFTHolder::<T>::remove((acc_id, asset_id, nft_id));
+                // Per ERC-721, a per-token approval never survives a transfer. Only account
+                // holders can hold approvals, so this is the only arm that needs to clear one.
+                TokenApproval::<T>::remove(asset_id, nft_id);
             }
             AssetHolder::Portfolio(portfolio_id) => {
                 PortfolioPallet::<T>::remove_nft_from_portfolio(portfolio_id, asset_id, nft_id);

--- a/pallets/nft/src/migrations.rs
+++ b/pallets/nft/src/migrations.rs
@@ -1,0 +1,107 @@
+// This file is part of the Polymesh distribution (https://github.com/PolymeshAssociation/Polymesh).
+// Copyright (c) 2020 Polymesh Association
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Storage migrations for `pallet-nft`.
+
+use frame_support::migrations::VersionedMigration;
+use frame_support::traits::{Get, UncheckedOnRuntimeUpgrade};
+use frame_support::weights::Weight;
+use sp_std::collections::btree_map::BTreeMap;
+
+use polymesh_primitives::asset::AssetId;
+use polymesh_primitives::nft::{NFTCount, NFTOwnerStatus};
+use polymesh_primitives::AccountId as AccountId32;
+
+use crate::{Config, NFTAccountCount, NFTHolder, Pallet};
+
+/// Backfills [`NFTAccountCount`] from the existing [`NFTHolder`] entries.
+pub struct BackfillNFTAccountCount<T>(core::marker::PhantomData<T>);
+
+impl<T: Config> UncheckedOnRuntimeUpgrade for BackfillNFTAccountCount<T> {
+    fn on_runtime_upgrade() -> Weight {
+        let mut counts: BTreeMap<(AccountId32, AssetId), NFTCount> = BTreeMap::new();
+        let mut entries_read: u64 = 0;
+
+        for ((acc_id, asset_id, _nft_id), status) in NFTHolder::<T>::iter() {
+            entries_read = entries_read.saturating_add(1);
+            match status {
+                NFTOwnerStatus::Owner | NFTOwnerStatus::OwnerLocked => {
+                    let count = counts.entry((acc_id, asset_id)).or_default();
+                    *count = count.saturating_add(1);
+                }
+                NFTOwnerStatus::NotOwned => {}
+            }
+        }
+
+        let entries_written = counts.len() as u64;
+        for ((acc_id, asset_id), count) in counts {
+            // The zero-count case cannot occur here: entries are only created on increment.
+            NFTAccountCount::<T>::insert(acc_id, asset_id, count);
+        }
+
+        log::info!(
+            target: "runtime::nft",
+            "BackfillNFTAccountCount: read {} NFTHolder entries, wrote {} NFTAccountCount entries",
+            entries_read,
+            entries_written,
+        );
+
+        T::DbWeight::get().reads_writes(entries_read.saturating_add(1), entries_written)
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<sp_std::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+        use codec::Encode;
+        frame_support::ensure!(
+            NFTAccountCount::<T>::iter().next().is_none(),
+            "NFTAccountCount is not empty before the migration"
+        );
+        let holdings = NFTHolder::<T>::iter()
+            .filter(|(_, status)| !matches!(status, NFTOwnerStatus::NotOwned))
+            .count() as u64;
+        Ok(holdings.encode())
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(state: sp_std::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+        use codec::Decode;
+        let expected: u64 =
+            Decode::decode(&mut &state[..]).map_err(|_| "failed to decode pre_upgrade state")?;
+        let total: u64 = NFTAccountCount::<T>::iter()
+            .map(|(_, _, count)| count)
+            .sum();
+        frame_support::ensure!(
+            total == expected,
+            "NFTAccountCount total does not match the number of NFTHolder entries"
+        );
+        // Every counted entry must be non-zero.
+        frame_support::ensure!(
+            NFTAccountCount::<T>::iter().all(|(_, _, count)| count > 0),
+            "NFTAccountCount contains a zero entry"
+        );
+        Ok(())
+    }
+}
+
+/// Migrates `pallet-nft` storage from version 7 to version 8.
+///
+/// Adds [`NFTAccountCount`], backfilled from [`NFTHolder`].
+pub type MigrateToV8<T> = VersionedMigration<
+    7,
+    8,
+    BackfillNFTAccountCount<T>,
+    Pallet<T>,
+    <T as frame_system::Config>::DbWeight,
+>;

--- a/pallets/portfolio/src/benchmarking.rs
+++ b/pallets/portfolio/src/benchmarking.rs
@@ -135,7 +135,7 @@ benchmarks! {
         Pallet::<T>::create_portfolio(alice.clone().origin().into(), PortfolioName(b"MyOwnPortfolio".to_vec())).unwrap();
         // Simulates minting - Adding the NFT pallet causes cyclic dependency
         let nft_asset_id = AssetId::new([0; 16]);
-        (1..n + 1).for_each(|id| PortfolioNFT::<T>::insert((&alice_default_portfolio, nft_asset_id, NFTId(id.into())), true));
+        (1..n + 1).for_each(|id| Pallet::<T>::add_nft_to_portfolio(alice_default_portfolio.clone(), nft_asset_id, NFTId(id.into())));
 
         let nfts = NFTs::new_unverified(nft_asset_id, (1..n + 1).map(|id| NFTId(id.into())).collect());
         let mut funds = vec![Fund { description: FundDescription::NonFungible(nfts), memo: None }];

--- a/pallets/portfolio/src/lib.rs
+++ b/pallets/portfolio/src/lib.rs
@@ -45,6 +45,8 @@
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 
+pub mod migrations;
+
 use core::mem;
 use frame_support::dispatch::DispatchResult;
 use frame_support::ensure;
@@ -56,6 +58,7 @@ use sp_std::prelude::*;
 
 use pallet_identity::PermissionedCallOriginData;
 use polymesh_primitives::asset::AssetId;
+use polymesh_primitives::nft::NFTCount;
 use polymesh_primitives::traits::{
     AffirmationFnConfig, AffirmationFnTrait, AssetFnConfig, AssetFnTrait, NFTTrait,
     PortfolioFnTrait,
@@ -205,7 +208,7 @@ pub mod pallet {
         RevokeCreatePortfoliosPermission(IdentityId, IdentityId),
     }
 
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(4);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(5);
 
     #[pallet::pallet]
     #[pallet::storage_version(STORAGE_VERSION)]
@@ -309,6 +312,22 @@ pub mod pallet {
         Blake2_128Concat,
         (AssetId, NFTId),
         bool,
+        ValueQuery,
+    >;
+
+    /// The number of NFTs of a given collection held by a portfolio.
+    ///
+    /// This is the portfolio-level counterpart of `pallet_nft::NFTAccountCount`, mirroring the
+    /// split used by `PortfolioFrozenAssets` / `pallet_asset::FrozenBalance`. A zero count is
+    /// never stored; the entry is removed instead.
+    #[pallet::storage]
+    pub type PortfolioNFTCount<T: Config> = StorageDoubleMap<
+        _,
+        Twox64Concat,
+        PortfolioId,
+        Blake2_128Concat,
+        AssetId,
+        NFTCount,
         ValueQuery,
     >;
 
@@ -1152,12 +1171,44 @@ impl<T: Config> Pallet<T> {
         asset_id: &AssetId,
         nft_id: &NFTId,
     ) {
+        if PortfolioNFT::<T>::contains_key((portfolio_id, asset_id, nft_id)) {
+            Self::mutate_portfolio_nft_count(portfolio_id, asset_id, |count| {
+                count.saturating_sub(1)
+            });
+        }
         PortfolioNFT::<T>::remove((portfolio_id, asset_id, nft_id));
     }
 
     /// Adds the nft to the owner's portfolio.
     pub fn add_nft_to_portfolio(portfolio_id: PortfolioId, asset_id: AssetId, nft_id: NFTId) {
+        if !PortfolioNFT::<T>::contains_key((&portfolio_id, &asset_id, &nft_id)) {
+            Self::mutate_portfolio_nft_count(&portfolio_id, &asset_id, |count| {
+                count.saturating_add(1)
+            });
+        }
         PortfolioNFT::<T>::insert((portfolio_id, asset_id, nft_id), true);
+    }
+
+    /// Returns the number of NFTs of `asset_id` held by `portfolio_id`.
+    pub fn get_portfolio_nft_count(portfolio_id: &PortfolioId, asset_id: &AssetId) -> NFTCount {
+        PortfolioNFTCount::<T>::get(portfolio_id, asset_id)
+    }
+
+    /// Mutates the number of NFTs of `asset_id` held by `portfolio_id`.
+    ///
+    /// `f` receives the current count and returns the new one. A resulting count of zero removes
+    /// the entry rather than storing the default.
+    pub fn mutate_portfolio_nft_count(
+        portfolio_id: &PortfolioId,
+        asset_id: &AssetId,
+        f: impl FnOnce(NFTCount) -> NFTCount,
+    ) {
+        let count = f(PortfolioNFTCount::<T>::get(portfolio_id, asset_id));
+        if count.is_zero() {
+            PortfolioNFTCount::<T>::remove(portfolio_id, asset_id);
+        } else {
+            PortfolioNFTCount::<T>::insert(portfolio_id, asset_id, count);
+        }
     }
 
     /// Locks the given nft.

--- a/pallets/portfolio/src/migrations.rs
+++ b/pallets/portfolio/src/migrations.rs
@@ -1,0 +1,101 @@
+// This file is part of the Polymesh distribution (https://github.com/PolymeshAssociation/Polymesh).
+// Copyright (c) 2020 Polymesh Association
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Storage migrations for `pallet-portfolio`.
+
+use frame_support::migrations::VersionedMigration;
+use frame_support::traits::{Get, UncheckedOnRuntimeUpgrade};
+use frame_support::weights::Weight;
+use sp_std::collections::btree_map::BTreeMap;
+
+use polymesh_primitives::asset::AssetId;
+use polymesh_primitives::nft::NFTCount;
+use polymesh_primitives::PortfolioId;
+
+use crate::{Config, Pallet, PortfolioNFT, PortfolioNFTCount};
+
+/// Backfills [`PortfolioNFTCount`] from the existing [`PortfolioNFT`] entries.
+pub struct BackfillPortfolioNFTCount<T>(core::marker::PhantomData<T>);
+
+impl<T: Config> UncheckedOnRuntimeUpgrade for BackfillPortfolioNFTCount<T> {
+    fn on_runtime_upgrade() -> Weight {
+        let mut counts: BTreeMap<(PortfolioId, AssetId), NFTCount> = BTreeMap::new();
+        let mut entries_read: u64 = 0;
+
+        for ((portfolio_id, asset_id, _nft_id), held) in PortfolioNFT::<T>::iter() {
+            entries_read = entries_read.saturating_add(1);
+            if held {
+                let count = counts.entry((portfolio_id, asset_id)).or_default();
+                *count = count.saturating_add(1);
+            }
+        }
+
+        let entries_written = counts.len() as u64;
+        for ((portfolio_id, asset_id), count) in counts {
+            // The zero-count case cannot occur here: entries are only created on increment.
+            PortfolioNFTCount::<T>::insert(portfolio_id, asset_id, count);
+        }
+
+        log::info!(
+            target: "runtime::portfolio",
+            "BackfillPortfolioNFTCount: read {} PortfolioNFT entries, wrote {} PortfolioNFTCount entries",
+            entries_read,
+            entries_written,
+        );
+
+        T::DbWeight::get().reads_writes(entries_read.saturating_add(1), entries_written)
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<sp_std::vec::Vec<u8>, sp_runtime::TryRuntimeError> {
+        use codec::Encode;
+        frame_support::ensure!(
+            PortfolioNFTCount::<T>::iter().next().is_none(),
+            "PortfolioNFTCount is not empty before the migration"
+        );
+        let holdings = PortfolioNFT::<T>::iter().filter(|(_, held)| *held).count() as u64;
+        Ok(holdings.encode())
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(state: sp_std::vec::Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+        use codec::Decode;
+        let expected: u64 =
+            Decode::decode(&mut &state[..]).map_err(|_| "failed to decode pre_upgrade state")?;
+        let total: u64 = PortfolioNFTCount::<T>::iter()
+            .map(|(_, _, count)| count)
+            .sum();
+        frame_support::ensure!(
+            total == expected,
+            "PortfolioNFTCount total does not match the number of PortfolioNFT entries"
+        );
+        frame_support::ensure!(
+            PortfolioNFTCount::<T>::iter().all(|(_, _, count)| count > 0),
+            "PortfolioNFTCount contains a zero entry"
+        );
+        Ok(())
+    }
+}
+
+/// Migrates `pallet-portfolio` storage from version 4 to version 5.
+///
+/// Adds [`PortfolioNFTCount`], backfilled from [`PortfolioNFT`].
+pub type MigrateToV5<T> = VersionedMigration<
+    4,
+    5,
+    BackfillPortfolioNFTCount<T>,
+    Pallet<T>,
+    <T as frame_system::Config>::DbWeight,
+>;

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -107,7 +107,9 @@ macro_rules! misc_pallet_impls {
             type MaxConsumers = frame_support::traits::ConstU32<16>;
             /// The set code logic, just the default since we're not a parachain.
             type SingleBlockMigrations = (
-                polymesh_runtime_common::migration::MigrateGrandpaToV5<Runtime>
+                polymesh_runtime_common::migration::MigrateGrandpaToV5<Runtime>,
+                pallet_portfolio::migrations::MigrateToV5<Runtime>,
+                pallet_nft::migrations::MigrateToV8<Runtime>,
             );
             type MultiBlockMigrator = MultiBlockMigrations;
             type PreInherents = ();

--- a/pallets/runtime/common/src/runtime.rs
+++ b/pallets/runtime/common/src/runtime.rs
@@ -1434,6 +1434,23 @@ macro_rules! runtime_apis {
                         &mut weight_meter
                     )
                 }
+
+                #[inline]
+                fn token_approval(
+                    asset_id: AssetId,
+                    nft_id: polymesh_primitives::NFTId,
+                ) -> Option<polymesh_primitives::AccountId> {
+                    pallet_nft::TokenApproval::<Runtime>::get(asset_id, nft_id)
+                }
+
+                #[inline]
+                fn operator_approval(
+                    owner: polymesh_primitives::AccountId,
+                    operator: polymesh_primitives::AccountId,
+                    asset_id: AssetId,
+                ) -> bool {
+                    pallet_nft::OperatorApproval::<Runtime>::get((&owner, &operator, &asset_id))
+                }
             }
 
             impl node_rpc_runtime_api::settlement::SettlementApi<Block> for Runtime {

--- a/pallets/runtime/tests/src/nft.rs
+++ b/pallets/runtime/tests/src/nft.rs
@@ -1,13 +1,14 @@
 use chrono::prelude::Utc;
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
 use frame_support::{assert_noop, assert_ok};
 
 use pallet_nft::Event;
 use pallet_nft::{
-    Collection, CollectionKeys, CurrentCollectionId, CurrentNFTId, MetadataValue, NFTsInCollection,
-    NumberOfNFTs, Owner,
+    Collection, CollectionKeys, CurrentCollectionId, CurrentNFTId, MetadataValue, NFTAccountCount,
+    NFTsInCollection, NumberOfNFTs, Owner,
 };
-use pallet_portfolio::PortfolioNFT;
-use polymesh_primitives::asset::{AssetId, AssetName, AssetType, NonFungibleType};
+use pallet_portfolio::{PortfolioNFT, PortfolioNFTCount};
+use polymesh_primitives::asset::{AssetHolder, AssetId, AssetName, AssetType, NonFungibleType};
 use polymesh_primitives::asset_metadata::{
     AssetMetadataKey, AssetMetadataLocalKey, AssetMetadataName, AssetMetadataSpec,
     AssetMetadataValue,
@@ -1298,6 +1299,285 @@ fn reject_instruction_with_locked_asset() {
                 PortfolioId::default_portfolio(alice.did).into(),
             ),
             NFTError::NFTIsNotLocked
+        );
+    });
+}
+
+/// `PortfolioNFTCount` tracks issue, transfer and redeem for portfolio holders.
+#[test]
+fn portfolio_nft_count_tracks_holdings() {
+    ExtBuilder::default().build().execute_with(|| {
+        set_timestamp(Utc::now().timestamp() as _);
+        System::set_block_number(1);
+
+        let alice: User = User::new(Sr25519Keyring::Alice);
+        let bob: User = User::new(Sr25519Keyring::Bob);
+        let alice_portfolio = PortfolioId::default_portfolio(alice.did);
+        let bob_portfolio = PortfolioId::default_portfolio(bob.did);
+
+        let mut weight_meter = WeightMeter::max_limit_no_minimum();
+
+        let asset_id = create_nft_collection(
+            alice.clone(),
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            Vec::new().into(),
+        );
+
+        // No holdings yet.
+        assert_eq!(
+            PortfolioNFTCount::<TestStorage>::get(&alice_portfolio, &asset_id),
+            0
+        );
+
+        // Issue two NFTs to Alice's default portfolio.
+        for _ in 0..2 {
+            mint_nft(
+                alice.clone(),
+                asset_id.clone(),
+                Vec::new(),
+                AssetHolderKind::DefaultPortfolio,
+            );
+        }
+        assert_eq!(
+            PortfolioNFTCount::<TestStorage>::get(&alice_portfolio, &asset_id),
+            2
+        );
+
+        // Transfer one to Bob.
+        ComplianceManager::pause_asset_compliance(alice.origin(), asset_id.clone()).unwrap();
+        let nfts = NFTs::new(asset_id, vec![NFTId(1)]).unwrap();
+        assert_ok!(with_transaction(|| {
+            NFT::base_nft_transfer(
+                alice_portfolio.clone().into(),
+                bob_portfolio.clone().into(),
+                nfts,
+                InstructionId(0),
+                None,
+                IdentityId::default(),
+                &mut weight_meter,
+            )
+        }));
+        assert_eq!(
+            PortfolioNFTCount::<TestStorage>::get(&alice_portfolio, &asset_id),
+            1
+        );
+        assert_eq!(
+            PortfolioNFTCount::<TestStorage>::get(&bob_portfolio, &asset_id),
+            1
+        );
+
+        // Redeem Alice's remaining NFT. The count drops to zero and the entry is removed
+        // rather than storing the default.
+        assert_ok!(NFT::redeem_nft(
+            alice.origin(),
+            asset_id,
+            NFTId(2),
+            AssetHolderKind::DefaultPortfolio,
+            None
+        ));
+        assert_eq!(
+            PortfolioNFTCount::<TestStorage>::get(&alice_portfolio, &asset_id),
+            0
+        );
+        assert!(!PortfolioNFTCount::<TestStorage>::contains_key(
+            &alice_portfolio,
+            &asset_id
+        ));
+    });
+}
+
+/// `NFTAccountCount` tracks issue, transfer and redeem for account-key holders.
+#[test]
+fn account_nft_count_tracks_holdings() {
+    ExtBuilder::default().build().execute_with(|| {
+        set_timestamp(Utc::now().timestamp() as _);
+        System::set_block_number(1);
+
+        let alice: User = User::new(Sr25519Keyring::Alice);
+        let bob: User = User::new(Sr25519Keyring::Bob);
+
+        let mut weight_meter = WeightMeter::max_limit_no_minimum();
+
+        let asset_id = create_nft_collection(
+            alice.clone(),
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            Vec::new().into(),
+        );
+
+        assert_eq!(
+            NFTAccountCount::<TestStorage>::get(&alice.acc(), &asset_id),
+            0
+        );
+
+        // Issue two NFTs to Alice's account key.
+        for _ in 0..2 {
+            mint_nft(
+                alice.clone(),
+                asset_id.clone(),
+                Vec::new(),
+                AssetHolderKind::Account,
+            );
+        }
+        assert_eq!(
+            NFTAccountCount::<TestStorage>::get(&alice.acc(), &asset_id),
+            2
+        );
+
+        // Transfer one to Bob's account key.
+        ComplianceManager::pause_asset_compliance(alice.origin(), asset_id.clone()).unwrap();
+        let nfts = NFTs::new(asset_id, vec![NFTId(1)]).unwrap();
+        assert_ok!(with_transaction(|| {
+            NFT::base_nft_transfer(
+                AssetHolder::Account(alice.acc()),
+                AssetHolder::Account(bob.acc()),
+                nfts,
+                InstructionId(0),
+                None,
+                IdentityId::default(),
+                &mut weight_meter,
+            )
+        }));
+        assert_eq!(
+            NFTAccountCount::<TestStorage>::get(&alice.acc(), &asset_id),
+            1
+        );
+        assert_eq!(
+            NFTAccountCount::<TestStorage>::get(&bob.acc(), &asset_id),
+            1
+        );
+
+        // Redeem Alice's remaining NFT; the entry is removed rather than zeroed.
+        assert_ok!(NFT::redeem_nft(
+            alice.origin(),
+            asset_id,
+            NFTId(2),
+            AssetHolderKind::Account,
+            None
+        ));
+        assert_eq!(
+            NFTAccountCount::<TestStorage>::get(&alice.acc(), &asset_id),
+            0
+        );
+        assert!(!NFTAccountCount::<TestStorage>::contains_key(
+            &alice.acc(),
+            &asset_id
+        ));
+    });
+}
+
+/// A controller transfer keeps both holders' counts consistent.
+#[test]
+fn nft_count_tracks_controller_transfer() {
+    ExtBuilder::default().build().execute_with(|| {
+        set_timestamp(Utc::now().timestamp() as _);
+        System::set_block_number(1);
+
+        let alice: User = User::new(Sr25519Keyring::Alice);
+        let bob: User = User::new(Sr25519Keyring::Bob);
+        let alice_portfolio = PortfolioId::default_portfolio(alice.did);
+        let bob_portfolio = PortfolioId::default_portfolio(bob.did);
+
+        let mut weight_meter = WeightMeter::max_limit_no_minimum();
+
+        let asset_id = create_nft_collection(
+            alice.clone(),
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            Vec::new().into(),
+        );
+        mint_nft(
+            alice.clone(),
+            asset_id.clone(),
+            Vec::new(),
+            AssetHolderKind::DefaultPortfolio,
+        );
+        ComplianceManager::pause_asset_compliance(alice.origin(), asset_id.clone()).unwrap();
+
+        let nfts = NFTs::new(asset_id, vec![NFTId(1)]).unwrap();
+        assert_ok!(with_transaction(|| {
+            NFT::base_nft_transfer(
+                alice_portfolio.clone().into(),
+                bob_portfolio.clone().into(),
+                nfts.clone(),
+                InstructionId(0),
+                None,
+                IdentityId::default(),
+                &mut weight_meter,
+            )
+        }));
+        assert_eq!(
+            PortfolioNFTCount::<TestStorage>::get(&bob_portfolio, &asset_id),
+            1
+        );
+
+        // Claw the NFT back.
+        assert_ok!(NFT::controller_transfer(
+            alice.origin(),
+            nfts,
+            bob_portfolio.clone().into(),
+            AssetHolderKind::DefaultPortfolio
+        ));
+        assert_eq!(
+            PortfolioNFTCount::<TestStorage>::get(&bob_portfolio, &asset_id),
+            0
+        );
+        assert_eq!(
+            PortfolioNFTCount::<TestStorage>::get(&alice_portfolio, &asset_id),
+            1
+        );
+    });
+}
+
+/// The v7 -> v8 migration backfills `NFTAccountCount` from `NFTHolder`, and the
+/// v4 -> v5 migration backfills `PortfolioNFTCount` from `PortfolioNFT`.
+#[test]
+fn nft_count_backfill_migration() {
+    ExtBuilder::default().build().execute_with(|| {
+        set_timestamp(Utc::now().timestamp() as _);
+        System::set_block_number(1);
+
+        let alice: User = User::new(Sr25519Keyring::Alice);
+        let alice_portfolio = PortfolioId::default_portfolio(alice.did);
+
+        let asset_id = create_nft_collection(
+            alice.clone(),
+            AssetType::NonFungible(NonFungibleType::Derivative),
+            Vec::new().into(),
+        );
+        for _ in 0..3 {
+            mint_nft(
+                alice.clone(),
+                asset_id.clone(),
+                Vec::new(),
+                AssetHolderKind::Account,
+            );
+        }
+        for _ in 0..2 {
+            mint_nft(
+                alice.clone(),
+                asset_id.clone(),
+                Vec::new(),
+                AssetHolderKind::DefaultPortfolio,
+            );
+        }
+
+        // Simulate a pre-migration chain: the holdings exist but the counts do not.
+        let _ = NFTAccountCount::<TestStorage>::clear(u32::MAX, None);
+        let _ = PortfolioNFTCount::<TestStorage>::clear(u32::MAX, None);
+        assert_eq!(NFTAccountCount::<TestStorage>::get(&alice.acc(), &asset_id), 0);
+        assert_eq!(
+            PortfolioNFTCount::<TestStorage>::get(&alice_portfolio, &asset_id),
+            0
+        );
+
+        <pallet_nft::migrations::BackfillNFTAccountCount<TestStorage> as UncheckedOnRuntimeUpgrade>
+            ::on_runtime_upgrade();
+        <pallet_portfolio::migrations::BackfillPortfolioNFTCount<TestStorage> as UncheckedOnRuntimeUpgrade>
+            ::on_runtime_upgrade();
+
+        assert_eq!(NFTAccountCount::<TestStorage>::get(&alice.acc(), &asset_id), 3);
+        assert_eq!(
+            PortfolioNFTCount::<TestStorage>::get(&alice_portfolio, &asset_id),
+            2
         );
     });
 }

--- a/pallets/runtime/tests/src/settlement_pallet/transfer_funds.rs
+++ b/pallets/runtime/tests/src/settlement_pallet/transfer_funds.rs
@@ -3,6 +3,7 @@ use sp_keyring::Sr25519Keyring;
 use sp_std::collections::btree_set::BTreeSet;
 
 use pallet_asset::{Allowances, AssetBalance, BalanceOf, LockedBalance};
+use pallet_nft::{NFTAccountCount, OperatorApproval, TokenApproval};
 use polymesh_primitives::asset::{AssetHolder, AssetHolderKind, AssetType, NonFungibleType};
 use polymesh_primitives::nft::{NFTId, NFTOwnerStatus};
 use polymesh_primitives::settlement::{AffirmationRequirement, Leg, SettlementType};
@@ -22,6 +23,7 @@ type Settlement = pallet_settlement::Pallet<TestStorage>;
 type Portfolio = pallet_portfolio::Pallet<TestStorage>;
 type SettlementError = pallet_settlement::Error<TestStorage>;
 type AssetError = pallet_asset::Error<TestStorage>;
+type NFTError = pallet_nft::Error<TestStorage>;
 type PortfolioError = pallet_portfolio::Error<TestStorage>;
 
 /// Helper to issue tokens to an Account holder.
@@ -322,6 +324,7 @@ fn spender_nft_rejected() {
         let bob = User::new(Sr25519Keyring::Bob);
         let asset_id = create_and_issue_to_account(&alice);
 
+        // A fungible allowance does not authorize an NFT transfer.
         assert_ok!(Asset::approve(alice.origin(), asset_id, bob.acc(), 500));
 
         let from = Some(AssetHolder::Account(alice.acc()));
@@ -336,7 +339,7 @@ fn spender_nft_rejected() {
 
         assert_noop!(
             Settlement::transfer_funds(bob.origin(), from, to, nft_fund),
-            SettlementError::AllowancesNotSupportedForNFTs
+            NFTError::InsufficientNFTApproval
         );
     });
 }
@@ -478,16 +481,15 @@ fn nft_cross_identity_creates_settlement() {
 }
 
 #[test]
-fn nft_spender_rejected() {
+fn nft_spender_rejected_without_approval() {
     ExtBuilder::default().build().execute_with(|| {
         let alice = User::new(Sr25519Keyring::Alice);
         let bob = User::new(Sr25519Keyring::Bob);
         let asset_id = create_and_issue_nft_to_account(&alice);
 
-        // Approve bob as spender (fungible allowance).
+        // A fungible allowance is not an NFT approval.
         assert_ok!(Asset::approve(alice.origin(), asset_id, bob.acc(), 500));
 
-        // Bob tries to transfer alice's NFT — rejected (allowances not supported for NFTs).
         assert_noop!(
             Settlement::transfer_funds(
                 bob.origin(),
@@ -495,7 +497,261 @@ fn nft_spender_rejected() {
                 AssetHolder::Account(bob.acc()),
                 non_fungible_fund(asset_id, NFTId(1)),
             ),
-            SettlementError::AllowancesNotSupportedForNFTs
+            NFTError::InsufficientNFTApproval
+        );
+    });
+}
+
+/// A per-token approval lets the spender move exactly that NFT, once.
+#[test]
+fn nft_spender_with_token_approval() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(Sr25519Keyring::Alice);
+        let bob = User::new(Sr25519Keyring::Bob);
+        let asset_id = create_and_issue_nft_to_account(&alice);
+
+        assert_ok!(Nft::approve(
+            alice.origin(),
+            asset_id,
+            NFTId(1),
+            Some(bob.acc())
+        ));
+        assert_eq!(
+            TokenApproval::<TestStorage>::get(asset_id, NFTId(1)),
+            Some(bob.acc())
+        );
+
+        assert_ok!(Settlement::transfer_funds(
+            bob.origin(),
+            Some(AssetHolder::Account(alice.acc())),
+            AssetHolder::Account(bob.acc()),
+            non_fungible_fund(asset_id, NFTId(1)),
+        ));
+
+        // The approval was consumed and did not survive the transfer.
+        assert_eq!(TokenApproval::<TestStorage>::get(asset_id, NFTId(1)), None);
+        assert_eq!(
+            NFTAccountCount::<TestStorage>::get(&bob.acc(), &asset_id),
+            1
+        );
+    });
+}
+
+/// A per-token approval for one NFT does not authorize a different NFT.
+#[test]
+fn nft_token_approval_is_per_token() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(Sr25519Keyring::Alice);
+        let bob = User::new(Sr25519Keyring::Bob);
+        let asset_id = create_and_issue_nft_to_account(&alice);
+        // Issue a second NFT into alice's account.
+        assert_ok!(Nft::issue_nft(
+            alice.origin(),
+            asset_id,
+            Vec::new(),
+            AssetHolderKind::Account
+        ));
+
+        assert_ok!(Nft::approve(
+            alice.origin(),
+            asset_id,
+            NFTId(1),
+            Some(bob.acc())
+        ));
+
+        assert_noop!(
+            Settlement::transfer_funds(
+                bob.origin(),
+                Some(AssetHolder::Account(alice.acc())),
+                AssetHolder::Account(bob.acc()),
+                non_fungible_fund(asset_id, NFTId(2)),
+            ),
+            NFTError::InsufficientNFTApproval
+        );
+    });
+}
+
+/// A collection-wide operator approval covers every NFT and is not consumed on use.
+#[test]
+fn nft_spender_with_operator_approval() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(Sr25519Keyring::Alice);
+        let bob = User::new(Sr25519Keyring::Bob);
+        let asset_id = create_and_issue_nft_to_account(&alice);
+        assert_ok!(Nft::issue_nft(
+            alice.origin(),
+            asset_id,
+            Vec::new(),
+            AssetHolderKind::Account
+        ));
+
+        assert_ok!(Nft::set_approval_for_all(
+            alice.origin(),
+            asset_id,
+            bob.acc(),
+            true
+        ));
+
+        // Both NFTs can be moved without any per-token approval.
+        for nft_id in [NFTId(1), NFTId(2)] {
+            assert_ok!(Settlement::transfer_funds(
+                bob.origin(),
+                Some(AssetHolder::Account(alice.acc())),
+                AssetHolder::Account(bob.acc()),
+                non_fungible_fund(asset_id, nft_id),
+            ));
+        }
+
+        // The operator approval survives.
+        assert!(OperatorApproval::<TestStorage>::get((
+            &alice.acc(),
+            &bob.acc(),
+            &asset_id
+        )));
+        assert_eq!(
+            NFTAccountCount::<TestStorage>::get(&bob.acc(), &asset_id),
+            2
+        );
+    });
+}
+
+/// Revoking an operator approval stops further transfers.
+#[test]
+fn nft_operator_approval_revoked() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(Sr25519Keyring::Alice);
+        let bob = User::new(Sr25519Keyring::Bob);
+        let asset_id = create_and_issue_nft_to_account(&alice);
+
+        assert_ok!(Nft::set_approval_for_all(
+            alice.origin(),
+            asset_id,
+            bob.acc(),
+            true
+        ));
+        assert_ok!(Nft::set_approval_for_all(
+            alice.origin(),
+            asset_id,
+            bob.acc(),
+            false
+        ));
+        // `false` is never stored; the entry is removed instead.
+        assert!(!OperatorApproval::<TestStorage>::contains_key((
+            &alice.acc(),
+            &bob.acc(),
+            &asset_id
+        )));
+
+        assert_noop!(
+            Settlement::transfer_funds(
+                bob.origin(),
+                Some(AssetHolder::Account(alice.acc())),
+                AssetHolder::Account(bob.acc()),
+                non_fungible_fund(asset_id, NFTId(1)),
+            ),
+            NFTError::InsufficientNFTApproval
+        );
+    });
+}
+
+/// Only the holder, or an approved operator, may set a per-token approval.
+#[test]
+fn nft_approve_unauthorized() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(Sr25519Keyring::Alice);
+        let bob = User::new(Sr25519Keyring::Bob);
+        let charlie = User::new(Sr25519Keyring::Charlie);
+        let asset_id = create_and_issue_nft_to_account(&alice);
+
+        // Bob does not hold the NFT and is not an operator.
+        assert_noop!(
+            Nft::approve(bob.origin(), asset_id, NFTId(1), Some(charlie.acc())),
+            NFTError::NFTApprovalNotAuthorized
+        );
+
+        // As an operator, bob may approve on alice's behalf.
+        assert_ok!(Nft::set_approval_for_all(
+            alice.origin(),
+            asset_id,
+            bob.acc(),
+            true
+        ));
+        assert_ok!(Nft::approve(
+            bob.origin(),
+            asset_id,
+            NFTId(1),
+            Some(charlie.acc())
+        ));
+        assert_eq!(
+            TokenApproval::<TestStorage>::get(asset_id, NFTId(1)),
+            Some(charlie.acc())
+        );
+    });
+}
+
+/// A per-token approval is cleared when the NFT is transferred by its owner.
+#[test]
+fn nft_token_approval_cleared_on_transfer() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(Sr25519Keyring::Alice);
+        let bob = User::new(Sr25519Keyring::Bob);
+        let charlie = User::new(Sr25519Keyring::Charlie);
+        let asset_id = create_and_issue_nft_to_account(&alice);
+
+        assert_ok!(Nft::approve(
+            alice.origin(),
+            asset_id,
+            NFTId(1),
+            Some(charlie.acc())
+        ));
+
+        // Alice moves the NFT herself; charlie's approval must not follow it.
+        assert_ok!(Settlement::transfer_funds(
+            alice.origin(),
+            None,
+            AssetHolder::Account(bob.acc()),
+            non_fungible_fund(asset_id, NFTId(1)),
+        ));
+
+        assert_eq!(TokenApproval::<TestStorage>::get(asset_id, NFTId(1)), None);
+        assert_noop!(
+            Settlement::transfer_funds(
+                charlie.origin(),
+                Some(AssetHolder::Account(bob.acc())),
+                AssetHolder::Account(charlie.acc()),
+                non_fungible_fund(asset_id, NFTId(1)),
+            ),
+            NFTError::InsufficientNFTApproval
+        );
+    });
+}
+
+/// An operator approval is scoped to a single collection.
+#[test]
+fn nft_operator_approval_is_per_collection() {
+    ExtBuilder::default().build().execute_with(|| {
+        let alice = User::new(Sr25519Keyring::Alice);
+        let bob = User::new(Sr25519Keyring::Bob);
+        let asset_id_a = create_and_issue_nft_to_account(&alice);
+        let asset_id_b = create_and_issue_nft_to_account(&alice);
+        assert_ne!(asset_id_a, asset_id_b);
+
+        assert_ok!(Nft::set_approval_for_all(
+            alice.origin(),
+            asset_id_a,
+            bob.acc(),
+            true
+        ));
+
+        // Collection B is untouched by the approval on collection A.
+        assert_noop!(
+            Settlement::transfer_funds(
+                bob.origin(),
+                Some(AssetHolder::Account(alice.acc())),
+                AssetHolder::Account(bob.acc()),
+                non_fungible_fund(asset_id_b, NFTId(1)),
+            ),
+            NFTError::InsufficientNFTApproval
         );
     });
 }

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -591,6 +591,9 @@ pub mod pallet {
         ReceiptExpired,
         /// Source and destination are the exact same AssetHolder.
         SenderSameAsReceiver,
+        /// Deprecated placeholder kept to preserve error indices after removing
+        /// `AllowancesNotSupportedForNFTs` (NFT spender transfers now use approvals).
+        DeprecatedAllowancesNotSupportedForNFTs,
         /// The instruction is already locked. It must be unlocked before relocking.
         InstructionAlreadyLocked,
         /// The instruction is not in `LockedForExecution` status and cannot be unlocked.

--- a/pallets/settlement/src/lib.rs
+++ b/pallets/settlement/src/lib.rs
@@ -72,6 +72,7 @@ use sp_std::vec;
 use pallet_asset::MandatoryMediators;
 use pallet_base::{ensure_string_limited, try_next_post};
 use pallet_identity::DidRecords;
+use pallet_nft::WeightInfo as NFTWeightInfo;
 use polymesh_primitives::asset::AssetId;
 use polymesh_primitives::constants::queue_priority::SETTLEMENT_INSTRUCTION_EXECUTION_PRIORITY;
 use polymesh_primitives::crypto::{ChainScopedMessage, SETTLEMENT_RECEIPT_LABEL};
@@ -590,8 +591,6 @@ pub mod pallet {
         ReceiptExpired,
         /// Source and destination are the exact same AssetHolder.
         SenderSameAsReceiver,
-        /// Spender allowances are not supported for non-fungible token transfers.
-        AllowancesNotSupportedForNFTs,
         /// The instruction is already locked. It must be unlocked before relocking.
         InstructionAlreadyLocked,
         /// The instruction is not in `LockedForExecution` status and cannot be unlocked.
@@ -1655,7 +1654,9 @@ impl<T: Config> Pallet<T> {
 
     /// Authorize the transfer source.
     ///
-    /// - Account source where caller != owner: checks and decrements spender allowance.
+    /// - Account source where caller != owner: checks and consumes the spender's approval.
+    ///   Fungible funds use the `pallet_asset` allowance; NFTs use the `pallet_nft` per-token or
+    ///   collection-wide operator approval.
     /// - Portfolio source: checks custody.
     fn ensure_transfer_source_authorized(
         resolved_from: &AssetHolder,
@@ -1677,8 +1678,14 @@ impl<T: Config> Pallet<T> {
                                 *amount,
                             )?;
                         }
-                        FundDescription::NonFungible(_) => {
-                            return Err(Error::<T>::AllowancesNotSupportedForNFTs.into());
+                        FundDescription::NonFungible(nfts) => {
+                            Self::check_accrue(
+                                weight_meter,
+                                <T as pallet_nft::Config>::WeightInfo::spend_nft_approval(
+                                    nfts.len() as u32,
+                                ),
+                            )?;
+                            Nft::<T>::spend_nft_approval(owner, &caller_data.sender, nfts)?;
                         }
                     }
                 }
@@ -4125,9 +4132,15 @@ impl<T: Config> SettlementFnTrait<T> for Pallet<T> {
             asset_count.non_fungible(),
             0,
         ));
-        // Spender allowance only applies when caller differs from owner and source is an account.
+        // Spender approval only applies when caller differs from owner and source is an account.
+        // The fungible and non-fungible paths consume different approvals, so charge accordingly.
         if matches!(from, Some(AssetHolder::Account(_))) {
-            limit = limit.saturating_add(T::AssetFn::spend_allowance_weight());
+            limit = limit.saturating_add(match &fund.description {
+                FundDescription::Fungible { .. } => T::AssetFn::spend_allowance_weight(),
+                FundDescription::NonFungible(nfts) => {
+                    <T as pallet_nft::Config>::WeightInfo::spend_nft_approval(nfts.len() as u32)
+                }
+            });
         }
         // Memo write only happens in the cross-DID path when a memo is provided.
         if fund.memo.is_some() {

--- a/pallets/weights/src/pallet_nft.rs
+++ b/pallets/weights/src/pallet_nft.rs
@@ -99,20 +99,22 @@ impl pallet_nft::WeightInfo for SubstrateWeight {
     // Proof: `Nft::NumberOfNFTs` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
     // Storage: `Nft::CurrentNFTId` (r:1 w:1)
     // Proof: `Nft::CurrentNFTId` (`max_values`: None, `max_size`: Some(32), added: 2507, mode: `MaxEncodedLen`)
-    // Storage: `Portfolio::PortfolioNFT` (r:0 w:1)
+    // Storage: `Portfolio::PortfolioNFT` (r:1 w:1)
     // Proof: `Portfolio::PortfolioNFT` (`max_values`: None, `max_size`: Some(106), added: 2581, mode: `MaxEncodedLen`)
+    // Storage: `Portfolio::PortfolioNFTCount` (r:1 w:1)
+    // Proof: `Portfolio::PortfolioNFTCount` (`max_values`: None, `max_size`: Some(89), added: 2564, mode: `MaxEncodedLen`)
     // Storage: `Nft::MetadataValue` (r:0 w:255)
     // Proof: `Nft::MetadataValue` (`max_values`: None, `max_size`: None, mode: `Measured`)
     // Storage: `Nft::Owner` (r:0 w:1)
     // Proof: `Nft::Owner` (`max_values`: None, `max_size`: Some(98), added: 2573, mode: `MaxEncodedLen`)
     /// The range of component `n` is `[1, 255]`.
     fn issue_nft(n: u32) -> Weight {
-        // Minimum execution time: 64_510 nanoseconds.
-        Weight::from_parts(64_950_393, 0)
-            // Standard Error: 3_252
-            .saturating_add(Weight::from_parts(3_131_890, 0).saturating_mul(n.into()))
-            .saturating_add(DbWeight::get().reads(9))
-            .saturating_add(DbWeight::get().writes(5))
+        // Minimum execution time: 47_078 nanoseconds.
+        Weight::from_parts(59_541_159, 0)
+            // Standard Error: 2_040
+            .saturating_add(Weight::from_parts(1_923_122, 0).saturating_mul(n.into()))
+            .saturating_add(DbWeight::get().reads(11))
+            .saturating_add(DbWeight::get().writes(6))
             .saturating_add(DbWeight::get().writes((1_u64).saturating_mul(n.into())))
     }
     // Storage: `Nft::CollectionAsset` (r:1 w:0)
@@ -135,46 +137,52 @@ impl pallet_nft::WeightInfo for SubstrateWeight {
     // Proof: `Nft::NFTsInCollection` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
     // Storage: `Nft::NumberOfNFTs` (r:1 w:1)
     // Proof: `Nft::NumberOfNFTs` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
+    // Storage: `Portfolio::PortfolioNFTCount` (r:1 w:1)
+    // Proof: `Portfolio::PortfolioNFTCount` (`max_values`: None, `max_size`: Some(89), added: 2564, mode: `MaxEncodedLen`)
     // Storage: `Nft::MetadataValue` (r:256 w:255)
     // Proof: `Nft::MetadataValue` (`max_values`: None, `max_size`: None, mode: `Measured`)
     // Storage: `Nft::Owner` (r:0 w:1)
     // Proof: `Nft::Owner` (`max_values`: None, `max_size`: Some(98), added: 2573, mode: `MaxEncodedLen`)
     /// The range of component `n` is `[1, 255]`.
     fn redeem_nft(n: u32) -> Weight {
-        // Minimum execution time: 86_870 nanoseconds.
-        Weight::from_parts(79_887_615, 0)
-            // Standard Error: 4_626
-            .saturating_add(Weight::from_parts(5_203_865, 0).saturating_mul(n.into()))
-            .saturating_add(DbWeight::get().reads(11))
+        // Minimum execution time: 56_645 nanoseconds.
+        Weight::from_parts(63_067_267, 0)
+            // Standard Error: 4_372
+            .saturating_add(Weight::from_parts(3_171_657, 0).saturating_mul(n.into()))
+            .saturating_add(DbWeight::get().reads(12))
             .saturating_add(DbWeight::get().reads((1_u64).saturating_mul(n.into())))
-            .saturating_add(DbWeight::get().writes(4))
+            .saturating_add(DbWeight::get().writes(5))
             .saturating_add(DbWeight::get().writes((1_u64).saturating_mul(n.into())))
     }
     // Storage: `Nft::CollectionAsset` (r:1 w:0)
     // Proof: `Nft::CollectionAsset` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
     // Storage: `Nft::NumberOfNFTs` (r:2 w:2)
     // Proof: `Nft::NumberOfNFTs` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
-    // Storage: `Portfolio::PortfolioNFT` (r:10 w:20)
+    // Storage: `Portfolio::PortfolioNFT` (r:20 w:20)
     // Proof: `Portfolio::PortfolioNFT` (`max_values`: None, `max_size`: Some(106), added: 2581, mode: `MaxEncodedLen`)
     // Storage: `Portfolio::PortfolioLockedNFT` (r:10 w:0)
     // Proof: `Portfolio::PortfolioLockedNFT` (`max_values`: None, `max_size`: Some(90), added: 2565, mode: `MaxEncodedLen`)
+    // Storage: `Portfolio::FrozenPortfolios` (r:1 w:0)
+    // Proof: `Portfolio::FrozenPortfolios` (`max_values`: None, `max_size`: Some(82), added: 2557, mode: `MaxEncodedLen`)
     // Storage: `Asset::Frozen` (r:1 w:0)
     // Proof: `Asset::Frozen` (`max_values`: None, `max_size`: Some(33), added: 2508, mode: `MaxEncodedLen`)
     // Storage: `Identity::DidRecords` (r:1 w:0)
     // Proof: `Identity::DidRecords` (`max_values`: None, `max_size`: Some(65), added: 2540, mode: `MaxEncodedLen`)
     // Storage: `ComplianceManager::AssetCompliances` (r:1 w:0)
     // Proof: `ComplianceManager::AssetCompliances` (`max_values`: None, `max_size`: None, mode: `Measured`)
+    // Storage: `Portfolio::PortfolioNFTCount` (r:2 w:2)
+    // Proof: `Portfolio::PortfolioNFTCount` (`max_values`: None, `max_size`: Some(89), added: 2564, mode: `MaxEncodedLen`)
     // Storage: `Nft::Owner` (r:0 w:10)
     // Proof: `Nft::Owner` (`max_values`: None, `max_size`: Some(98), added: 2573, mode: `MaxEncodedLen`)
     /// The range of component `n` is `[1, 10]`.
     fn base_nft_transfer(n: u32) -> Weight {
-        // Minimum execution time: 123_560 nanoseconds.
-        Weight::from_parts(104_023_838, 0)
-            // Standard Error: 62_378
-            .saturating_add(Weight::from_parts(23_884_787, 0).saturating_mul(n.into()))
-            .saturating_add(DbWeight::get().reads(6))
-            .saturating_add(DbWeight::get().reads((2_u64).saturating_mul(n.into())))
-            .saturating_add(DbWeight::get().writes(2))
+        // Minimum execution time: 95_518 nanoseconds.
+        Weight::from_parts(76_086_915, 0)
+            // Standard Error: 52_520
+            .saturating_add(Weight::from_parts(26_669_455, 0).saturating_mul(n.into()))
+            .saturating_add(DbWeight::get().reads(9))
+            .saturating_add(DbWeight::get().reads((3_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().writes(4))
             .saturating_add(DbWeight::get().writes((3_u64).saturating_mul(n.into())))
     }
     // Storage: `Identity::KeyRecords` (r:1 w:0)
@@ -193,21 +201,59 @@ impl pallet_nft::WeightInfo for SubstrateWeight {
     // Proof: `Nft::CollectionAsset` (`max_values`: None, `max_size`: Some(40), added: 2515, mode: `MaxEncodedLen`)
     // Storage: `Nft::NumberOfNFTs` (r:2 w:2)
     // Proof: `Nft::NumberOfNFTs` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
-    // Storage: `Portfolio::PortfolioNFT` (r:10 w:20)
+    // Storage: `Portfolio::PortfolioNFT` (r:20 w:20)
     // Proof: `Portfolio::PortfolioNFT` (`max_values`: None, `max_size`: Some(106), added: 2581, mode: `MaxEncodedLen`)
     // Storage: `Portfolio::PortfolioLockedNFT` (r:10 w:0)
     // Proof: `Portfolio::PortfolioLockedNFT` (`max_values`: None, `max_size`: Some(90), added: 2565, mode: `MaxEncodedLen`)
+    // Storage: `Portfolio::PortfolioNFTCount` (r:2 w:2)
+    // Proof: `Portfolio::PortfolioNFTCount` (`max_values`: None, `max_size`: Some(89), added: 2564, mode: `MaxEncodedLen`)
     // Storage: `Nft::Owner` (r:0 w:10)
     // Proof: `Nft::Owner` (`max_values`: None, `max_size`: Some(98), added: 2573, mode: `MaxEncodedLen`)
     /// The range of component `n` is `[1, 10]`.
     fn controller_transfer(n: u32) -> Weight {
-        // Minimum execution time: 90_760 nanoseconds.
-        Weight::from_parts(70_873_139, 0)
-            // Standard Error: 45_636
-            .saturating_add(Weight::from_parts(23_442_699, 0).saturating_mul(n.into()))
-            .saturating_add(DbWeight::get().reads(9))
-            .saturating_add(DbWeight::get().reads((2_u64).saturating_mul(n.into())))
-            .saturating_add(DbWeight::get().writes(2))
+        // Minimum execution time: 70_422 nanoseconds.
+        Weight::from_parts(53_679_613, 0)
+            // Standard Error: 60_000
+            .saturating_add(Weight::from_parts(25_645_276, 0).saturating_mul(n.into()))
+            .saturating_add(DbWeight::get().reads(11))
+            .saturating_add(DbWeight::get().reads((3_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().writes(4))
             .saturating_add(DbWeight::get().writes((3_u64).saturating_mul(n.into())))
+    }
+    // Storage: `Identity::KeyRecords` (r:1 w:0)
+    // Proof: `Identity::KeyRecords` (`max_values`: None, `max_size`: Some(73), added: 2548, mode: `MaxEncodedLen`)
+    // Storage: `Nft::NFTHolder` (r:1 w:0)
+    // Proof: `Nft::NFTHolder` (`max_values`: None, `max_size`: Some(97), added: 2572, mode: `MaxEncodedLen`)
+    // Storage: `Nft::TokenApproval` (r:0 w:1)
+    // Proof: `Nft::TokenApproval` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+    fn approve() -> Weight {
+        // Minimum execution time: 15_760 nanoseconds.
+        Weight::from_parts(19_897_000, 0)
+            .saturating_add(DbWeight::get().reads(2))
+            .saturating_add(DbWeight::get().writes(1))
+    }
+    // Storage: `Identity::KeyRecords` (r:1 w:0)
+    // Proof: `Identity::KeyRecords` (`max_values`: None, `max_size`: Some(73), added: 2548, mode: `MaxEncodedLen`)
+    // Storage: `Nft::OperatorApproval` (r:0 w:1)
+    // Proof: `Nft::OperatorApproval` (`max_values`: None, `max_size`: Some(129), added: 2604, mode: `MaxEncodedLen`)
+    fn set_approval_for_all() -> Weight {
+        // Minimum execution time: 12_002 nanoseconds.
+        Weight::from_parts(16_431_000, 0)
+            .saturating_add(DbWeight::get().reads(1))
+            .saturating_add(DbWeight::get().writes(1))
+    }
+    // Storage: `Nft::OperatorApproval` (r:1 w:0)
+    // Proof: `Nft::OperatorApproval` (`max_values`: None, `max_size`: Some(129), added: 2604, mode: `MaxEncodedLen`)
+    // Storage: `Nft::TokenApproval` (r:10 w:10)
+    // Proof: `Nft::TokenApproval` (`max_values`: None, `max_size`: Some(88), added: 2563, mode: `MaxEncodedLen`)
+    /// The range of component `n` is `[1, 10]`.
+    fn spend_nft_approval(n: u32) -> Weight {
+        // Minimum execution time: 11_702 nanoseconds.
+        Weight::from_parts(9_605_803, 0)
+            // Standard Error: 7_099
+            .saturating_add(Weight::from_parts(5_465_002, 0).saturating_mul(n.into()))
+            .saturating_add(DbWeight::get().reads(1))
+            .saturating_add(DbWeight::get().reads((1_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().writes((1_u64).saturating_mul(n.into())))
     }
 }

--- a/pallets/weights/src/pallet_portfolio.rs
+++ b/pallets/weights/src/pallet_portfolio.rs
@@ -125,9 +125,11 @@ impl pallet_portfolio::WeightInfo for SubstrateWeight {
     // Proof: `Portfolio::Portfolios` (`max_values`: None, `max_size`: None, mode: `Measured`)
     // Storage: `Portfolio::PortfolioCustodian` (r:1 w:0)
     // Proof: `Portfolio::PortfolioCustodian` (`max_values`: None, `max_size`: Some(81), added: 2556, mode: `MaxEncodedLen`)
+    // Storage: `Portfolio::FrozenPortfolios` (r:11 w:0)
+    // Proof: `Portfolio::FrozenPortfolios` (`max_values`: None, `max_size`: Some(82), added: 2557, mode: `MaxEncodedLen`)
     // Storage: `Asset::Frozen` (r:11 w:0)
     // Proof: `Asset::Frozen` (`max_values`: None, `max_size`: Some(33), added: 2508, mode: `MaxEncodedLen`)
-    // Storage: `Portfolio::PortfolioNFT` (r:100 w:200)
+    // Storage: `Portfolio::PortfolioNFT` (r:200 w:200)
     // Proof: `Portfolio::PortfolioNFT` (`max_values`: None, `max_size`: Some(106), added: 2581, mode: `MaxEncodedLen`)
     // Storage: `Portfolio::PortfolioLockedNFT` (r:100 w:0)
     // Proof: `Portfolio::PortfolioLockedNFT` (`max_values`: None, `max_size`: Some(90), added: 2565, mode: `MaxEncodedLen`)
@@ -137,6 +139,8 @@ impl pallet_portfolio::WeightInfo for SubstrateWeight {
     // Proof: `Portfolio::PortfolioAssetBalances` (`max_values`: None, `max_size`: Some(97), added: 2572, mode: `MaxEncodedLen`)
     // Storage: `Portfolio::PortfolioLockedAssets` (r:10 w:0)
     // Proof: `Portfolio::PortfolioLockedAssets` (`max_values`: None, `max_size`: Some(97), added: 2572, mode: `MaxEncodedLen`)
+    // Storage: `Portfolio::PortfolioNFTCount` (r:2 w:2)
+    // Proof: `Portfolio::PortfolioNFTCount` (`max_values`: None, `max_size`: Some(89), added: 2564, mode: `MaxEncodedLen`)
     // Storage: `Portfolio::PortfolioAssetCount` (r:1 w:1)
     // Proof: `Portfolio::PortfolioAssetCount` (`max_values`: None, `max_size`: Some(57), added: 2532, mode: `MaxEncodedLen`)
     // Storage: `Nft::Owner` (r:0 w:100)
@@ -144,16 +148,16 @@ impl pallet_portfolio::WeightInfo for SubstrateWeight {
     /// The range of component `f` is `[1, 10]`.
     /// The range of component `n` is `[1, 100]`.
     fn move_portfolio_funds(f: u32, n: u32) -> Weight {
-        // Minimum execution time: 410_510 nanoseconds.
-        Weight::from_parts(40_912_152, 0)
-            // Standard Error: 444_605
-            .saturating_add(Weight::from_parts(35_918_370, 0).saturating_mul(f.into()))
-            // Standard Error: 41_500
-            .saturating_add(Weight::from_parts(21_670_579, 0).saturating_mul(n.into()))
-            .saturating_add(DbWeight::get().reads(5))
-            .saturating_add(DbWeight::get().reads((5_u64).saturating_mul(f.into())))
-            .saturating_add(DbWeight::get().reads((2_u64).saturating_mul(n.into())))
-            .saturating_add(DbWeight::get().writes(1))
+        // Minimum execution time: 285_093 nanoseconds.
+        Weight::from_parts(77_616_316, 0)
+            // Standard Error: 169_740
+            .saturating_add(Weight::from_parts(19_436_656, 0).saturating_mul(f.into()))
+            // Standard Error: 15_843
+            .saturating_add(Weight::from_parts(24_440_340, 0).saturating_mul(n.into()))
+            .saturating_add(DbWeight::get().reads(8))
+            .saturating_add(DbWeight::get().reads((6_u64).saturating_mul(f.into())))
+            .saturating_add(DbWeight::get().reads((3_u64).saturating_mul(n.into())))
+            .saturating_add(DbWeight::get().writes(3))
             .saturating_add(DbWeight::get().writes((2_u64).saturating_mul(f.into())))
             .saturating_add(DbWeight::get().writes((3_u64).saturating_mul(n.into())))
     }

--- a/rpc/runtime-api/src/nft.rs
+++ b/rpc/runtime-api/src/nft.rs
@@ -18,11 +18,12 @@
 use frame_support::pallet_prelude::DispatchError;
 use sp_std::vec::Vec;
 
-use polymesh_primitives::{AssetHolder, NFTs, PortfolioId};
+use polymesh_primitives::asset::AssetId;
+use polymesh_primitives::{AccountId, AssetHolder, NFTId, NFTs, PortfolioId};
 
 sp_api::decl_runtime_apis! {
 
-    #[api_version(3)]
+    #[api_version(4)]
     pub trait NFTApi {
         #[changed_in(3)]
         fn transfer_report(
@@ -39,5 +40,15 @@ sp_api::decl_runtime_apis! {
             nfts: NFTs,
             skip_locked_check: bool,
         ) -> Vec<DispatchError>;
+
+        /// Returns the account approved to transfer `nft_id`, if any.
+        ///
+        /// This is the ERC-721 `getApproved`.
+        fn token_approval(asset_id: AssetId, nft_id: NFTId) -> Option<AccountId>;
+
+        /// Returns `true` if `operator` may transfer any NFT of `asset_id` held by `owner`.
+        ///
+        /// This is the ERC-721 `isApprovedForAll`, scoped to a single collection.
+        fn operator_approval(owner: AccountId, operator: AccountId, asset_id: AssetId) -> bool;
     }
 }


### PR DESCRIPTION
## changelog

### new features

- Adds per-account and per-portfolio NFT counts (`Nft::NFTAccountCount`, `Portfolio::PortfolioNFTCount`).
- Adds NFT approvals: per-token (`Nft::TokenApproval`) and collection-wide operator (`Nft::OperatorApproval`).
- `Settlement::transfer_funds` supports spender mode for NFTs, using the new approvals.

### modified external API

- `Settlement::transfer_funds` with `from = Some(Account)` and a caller other than the owner now accepts non-fungible funds, consuming an NFT approval instead of failing.

### new external API

- `Nft::approve(asset_id, nft_id, spender)` - sets or revokes the approved spender for a single NFT.
- `Nft::set_approval_for_all(asset_id, operator, approved)` - grants or revokes an operator for all of the caller's NFTs in a collection.

### new events

- `Nft::NFTApproval` - a per-token approval was set or revoked.
- `Nft::NFTApprovalForAll` - an operator approval was granted or revoked.
- `Nft::NFTApprovalSpent` - a spender used a per-token approval.

### other

- Removed `Settlement::AllowancesNotSupportedForNFTs`; NFT spender transfers now fail with `Nft::InsufficientNFTApproval`.
- Added `Nft::NFTApprovalNotAuthorized` and `Nft::InsufficientNFTApproval` errors.
- `NFTApi` runtime API bumped to version 4, adding `token_approval` and `operator_approval`.
- Per-token approvals are cleared whenever an NFT changes hands.

### data migration

- Backfill `Nft::NFTAccountCount` from `Nft::NFTHolder` (pallet-nft storage version 7 -> 8).
- Backfill `Portfolio::PortfolioNFTCount` from `Portfolio::PortfolioNFT` (pallet-portfolio storage version 4 -> 5).
