### PR TITLE
Fix `NFTApproval` event return

### DIFF
--- a/pallets/nft/src/lib.rs
+++ b/pallets/nft/src/lib.rs
@@ -981,16 +981,16 @@ impl<T: Config> Pallet<T> {
         spender: Option<T::AccountId>,
     ) -> DispatchResult {
         let caller_data = IdentityPallet::<T>::ensure_origin_call_permissions(origin)?;
-        let owner = Self::to_account_id32(&caller_data.sender)?;
+        let caller = Self::to_account_id32(&caller_data.sender)?;
 
-        // Only the account key currently holding the NFT, or an approved operator for the
-        // collection, may set a per-token approval.
-        let holder = AssetHolder::Account(owner.clone());
-        ensure!(
-            Self::is_holder_of_nft(&asset_id, &nft_id, &holder)
-                || Self::is_approved_operator_of_nft(&asset_id, &nft_id, &owner),
-            Error::<T>::NFTApprovalNotAuthorized
-        );
+        let owner = {
+            if Self::is_holder_of_nft(&asset_id, &nft_id, &AssetHolder::Account(caller.clone())) {
+                caller
+            } else {
+                Self::owner_if_approved_operator_of_nft(&asset_id, &nft_id, &caller)
+                    .ok_or(Error::<T>::NFTApprovalNotAuthorized)?
+            }
+        };
 
         let spender = spender.map(|s| Self::to_account_id32(&s)).transpose()?;
         match &spender {
@@ -1074,18 +1074,20 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// Returns `true` if `account` is an approved operator for the holder of `nft_id`.
-    fn is_approved_operator_of_nft(
+    /// Returns the owner of `nft_id` if `account` is an approved operator for it.
+    fn owner_if_approved_operator_of_nft(
         asset_id: &AssetId,
         nft_id: &NFTId,
         account: &AccountId32,
-    ) -> bool {
+    ) -> Option<AccountId32> {
         match Owner::<T>::get(asset_id, nft_id) {
-            Some(AssetHolder::Account(owner)) => {
-                OperatorApproval::<T>::get((&owner, account, asset_id))
+            Some(AssetHolder::Account(owner))
+                if OperatorApproval::<T>::get((&owner, account, asset_id)) =>
+            {
+                Some(owner)
             }
             // Portfolio-held NFTs cannot have approvals: `approve` requires an account holder.
-            _ => false,
+            _ => None,
         }
     }
 

--- a/pallets/precompiles/src/interface/nft/erc721.rs
+++ b/pallets/precompiles/src/interface/nft/erc721.rs
@@ -136,6 +136,8 @@ impl<T: Config> NonFungibleAssetInterface<T> {
         call: &INonFungibleAsset::approveCall,
         env: &mut impl Ext<T = T>,
     ) -> Result<Vec<u8>, Error> {
+        env.charge(<T as frame_system::Config>::DbWeight::get().reads(1))?;
+
         let caller = Common::<T>::caller(env)?;
         let nft_id = Self::nft_id(call.tokenId)?;
 

--- a/pallets/precompiles/src/interface/nft/erc721.rs
+++ b/pallets/precompiles/src/interface/nft/erc721.rs
@@ -156,10 +156,12 @@ impl<T: Config> NonFungibleAssetInterface<T> {
             },
         )?;
 
+        let owner = Self::account_owner_of(asset_id, &nft_id)?;
+
         Common::<T>::deposit_event(
             env,
             INonFungibleAssetEvents::Approval(INonFungibleAsset::Approval {
-                owner: caller.address.0.into(),
+                owner,
                 approved: call.to,
                 tokenId: call.tokenId,
             }),


### PR DESCRIPTION
## changelog
### modified events
 - `NFTApproval` returns the owner, instead of the caller
